### PR TITLE
Update WebAssembly WG URL

### DIFF
--- a/webassembly-wg-charter.html
+++ b/webassembly-wg-charter.html
@@ -70,7 +70,7 @@
       <h1 id="title">[DRAFT] WebAssembly Working Group Charter</h1>
 
       <p class="mission">The <strong>mission</strong> of the <a
-        href="https://www.w3.org/community/webassembly/">WebAssembly Working
+        href="https://www.w3.org/wasm/">WebAssembly Working
         Group</a> is to standardize a portable, size- and load-time-efficient
         format suitable for compilation to the web.</p>
 


### PR DESCRIPTION
Is this a right file to fix?

It says `[DRAFT]` [here](https://github.com/WebAssembly/wg-charter/blob/gh-pages/webassembly-wg-charter.html#L70), but I don't see this word in [published version](https://www.w3.org/2017/08/wasm-charter)